### PR TITLE
fixed bug: no showing images inside spoiler

### DIFF
--- a/public/js/spoiler.js
+++ b/public/js/spoiler.js
@@ -2,7 +2,6 @@
 
 $(document).ready(function () {
     'use strict';
-
     require([
         'translator'
     ], function (translator) {
@@ -52,6 +51,7 @@ $(document).ready(function () {
                             return console.error('Error has occurred, error: %s', error.message);
                         }
                         $content.html(content);
+                        $spoiler.find('img').attr('data-state', 'loaded');
                     }
                 );
             }


### PR DESCRIPTION
Because of this: https://github.com/NodeBB/NodeBB/blob/master/public/js-enabled.css images inside of spoilers are not being showed when user open the spoiler.