### PR TITLE
feat: composer-quill integration

### DIFF
--- a/public/js/composer.js
+++ b/public/js/composer.js
@@ -62,11 +62,11 @@ $(document).ready(function () {
     $(window).on('action:quill.load', function (ev, quill) {
         require(['quill', 'composer/formatting'], function (Quill, formatting) {
             // Override the composer-default handler for ns-spoiler and use one for Quill
-            const Delta = Quill.import('delta');
+            var Delta = Quill.import('delta');
 
             formatting.addButtonDispatch('ns-spoiler', function () {
-                const range = quill.getSelection();
-                let insertionDelta;
+                var range = quill.getSelection();
+                var insertionDelta;
 
                 if (range.length) {
                     insertionDelta = quill.getContents(range.index, range.length);
@@ -85,9 +85,9 @@ $(document).ready(function () {
 
                 if (range.length) {
                     // Update selection
-                    quill.setSelection(range.index + 5, range.length);
+                    quill.setSelection(range.index + (getTag().length), range.length);
                 } else {
-                    quill.setSelection(range.index + 5, textPrompt.length);
+                    quill.setSelection(range.index + (getTag().length), textPrompt.length);
                 }
             });
         });

--- a/public/js/composer.js
+++ b/public/js/composer.js
@@ -6,6 +6,10 @@ $(document).ready(function () {
         nl     = '\n',
         textPrompt = 'Spoiler Text';
 
+    function getTag() {
+        return nl + tag + nl;
+    }
+
     // Quill only adds buttons if there is a listener, so this adds a no-op and is overridden later on
     require(['composer/formatting'], function (formatting) {
         formatting.addButtonDispatch('ns-spoiler', function () {});
@@ -36,10 +40,6 @@ $(document).ready(function () {
 
             function getNewSpoiler(message) {
                 return getTag() + message + getTag();
-            }
-
-            function getTag() {
-                return nl + tag + nl;
             }
         });
     });
@@ -78,17 +78,16 @@ $(document).ready(function () {
                 quill.updateContents(new Delta()
                     .retain(range.index)
                     .delete(range.length)
-                    .insert(range.index > 0 ? '\n' : '')
-                    .insert(tag + nl)
+                    .insert(getTag())
                     .concat(insertionDelta)
-                    .insert(nl + tag + nl)
+                    .insert(getTag())
                 );
 
                 if (range.length) {
                     // Update selection
-                    quill.setSelection(range.index + (range.index > 0 ? 5 : 4), range.length);
+                    quill.setSelection(range.index + 5, range.length);
                 } else {
-                    quill.setSelection(range.index + (range.index > 0 ? 5 : 4), textPrompt.length);
+                    quill.setSelection(range.index + 5, textPrompt.length);
                 }
             });
         });

--- a/public/js/composer.js
+++ b/public/js/composer.js
@@ -2,21 +2,25 @@
 /* globals define, app, ajaxify, bootbox, socket, templates, utils */
 
 $(document).ready(function () {
-    require([
-        'composer/formatting', 'composer/controls'
-    ], function (formatting, controls) {
-        var tag    = ':::',
-            nl     = '\n',
-            textPrompt = 'Spoiler Text';
+    var tag    = ':::',
+        nl     = '\n',
+        textPrompt = 'Spoiler Text';
 
-        $(window).on('action:composer.loaded', function (ev, data) {
-            if ($.Redactor && $.Redactor.opts.plugins.indexOf('ns-spoiler') === -1) {
-                $.Redactor.opts.plugins.push('ns-spoiler');
-            }
-        });
+    // Quill only adds buttons if there is a listener, so this adds a no-op and is overridden later on
+    require(['composer/formatting'], function (formatting) {
+        formatting.addButtonDispatch('ns-spoiler', function () {});
+    });
 
-        $(window).on('action:composer.enhanced', function () {
-            console.log('enhanced adding its thin');
+    $(window).on('action:composer.loaded', function (ev, data) {
+        if ($.Redactor && $.Redactor.opts.plugins.indexOf('ns-spoiler') === -1) {
+            $.Redactor.opts.plugins.push('ns-spoiler');
+        }
+    });
+
+    $(window).on('action:composer.enhanced', function () {
+        require([
+            'composer/formatting', 'composer/controls'
+        ], function (formatting, controls) {
             formatting.addButtonDispatch('ns-spoiler', composerControlDidClick);
 
             function composerControlDidClick(textArea, selectionStart, selectionEnd) {
@@ -38,55 +42,54 @@ $(document).ready(function () {
                 return nl + tag + nl;
             }
         });
+    });
 
-        $(window).on('action:redactor.load', function () {
-            $.Redactor.prototype['ns-spoiler'] = function () {
-                return {
-                    init   : function () {
-                        var button = this.button.add('ns-spoiler', 'Add Spoiler');
-                        this.button.setIcon(button, '<i class="fa fa-eye-slash"></i>');
-                        this.button.addCallback(button, this['ns-spoiler'].onClick);
-                    },
-                    onClick: function () {
-                        this.insert.html('<p>' + tag + '<br /><br />' + textPrompt + '<br /><br />' + tag + '</p>');
-                    }
-                };
+    $(window).on('action:redactor.load', function () {
+        $.Redactor.prototype['ns-spoiler'] = function () {
+            return {
+                init   : function () {
+                    var button = this.button.add('ns-spoiler', 'Add Spoiler');
+                    this.button.setIcon(button, '<i class="fa fa-eye-slash"></i>');
+                    this.button.addCallback(button, this['ns-spoiler'].onClick);
+                },
+                onClick: function () {
+                    this.insert.html('<p>' + tag + '<br /><br />' + textPrompt + '<br /><br />' + tag + '</p>');
+                }
             };
-        });
+        };
+    });
 
-        $(window).on('action:quill.load', function (ev, quill) {
-            console.log('quill loaded');
-            require(['quill'], function (Quill) {
-                // Override the composer-default handler for ns-spoiler and use one for Quill
-                const Delta = Quill.import('delta');
+    $(window).on('action:quill.load', function (ev, quill) {
+        require(['quill', 'composer/formatting'], function (Quill, formatting) {
+            // Override the composer-default handler for ns-spoiler and use one for Quill
+            const Delta = Quill.import('delta');
 
-                formatting.addButtonDispatch('ns-spoiler', function () {
-                    const range = quill.getSelection();
-                    let insertionDelta;
+            formatting.addButtonDispatch('ns-spoiler', function () {
+                const range = quill.getSelection();
+                let insertionDelta;
 
-                    if (range.length) {
-                        insertionDelta = quill.getContents(range.index, range.length);
-                    } else {
-                        insertionDelta = new Delta().insert(textPrompt);
-                    }
+                if (range.length) {
+                    insertionDelta = quill.getContents(range.index, range.length);
+                } else {
+                    insertionDelta = new Delta().insert(textPrompt);
+                }
 
-                    // Wrap selection in spoiler tags
-                    quill.updateContents(new Delta()
-                        .retain(range.index)
-                        .delete(range.length)
-                        .insert(range.index > 0 ? '\n' : '')
-                        .insert(tag + nl)
-                        .concat(insertionDelta)
-                        .insert(nl + tag + nl)
-                    );
+                // Wrap selection in spoiler tags
+                quill.updateContents(new Delta()
+                    .retain(range.index)
+                    .delete(range.length)
+                    .insert(range.index > 0 ? '\n' : '')
+                    .insert(tag + nl)
+                    .concat(insertionDelta)
+                    .insert(nl + tag + nl)
+                );
 
-                    if (range.length) {
-                        // Update selection
-                        quill.setSelection(range.index + (range.index > 0 ? 5 : 4), range.length);
-                    } else {
-                        quill.setSelection(range.index + (range.index > 0 ? 5 : 4), textPrompt.length);
-                    }
-                });
+                if (range.length) {
+                    // Update selection
+                    quill.setSelection(range.index + (range.index > 0 ? 5 : 4), range.length);
+                } else {
+                    quill.setSelection(range.index + (range.index > 0 ? 5 : 4), textPrompt.length);
+                }
             });
         });
     });

--- a/public/js/composer.js
+++ b/public/js/composer.js
@@ -1,22 +1,22 @@
+'use strict';
 /* globals define, app, ajaxify, bootbox, socket, templates, utils */
 
 $(document).ready(function () {
-    'use strict';
+    require([
+        'composer/formatting', 'composer/controls'
+    ], function (formatting, controls) {
+        var tag    = ':::',
+            nl     = '\n',
+            textPrompt = 'Spoiler Text';
 
-    var tag    = ':::',
-        nl     = '\n\n',
-        textPrompt = 'Spoiler Text';
+        $(window).on('action:composer.loaded', function (ev, data) {
+            if ($.Redactor && $.Redactor.opts.plugins.indexOf('ns-spoiler') === -1) {
+                $.Redactor.opts.plugins.push('ns-spoiler');
+            }
+        });
 
-    $(window).on('action:composer.loaded', function (ev, data) {
-        if ($.Redactor && $.Redactor.opts.plugins.indexOf('ns-spoiler') === -1) {
-            $.Redactor.opts.plugins.push('ns-spoiler');
-        }
-    });
-
-    $(window).on('action:composer.enhanced', function () {
-        require([
-            'composer/formatting', 'composer/controls'
-        ], function (formatting, controls) {
+        $(window).on('action:composer.enhanced', function () {
+            console.log('enhanced adding its thin');
             formatting.addButtonDispatch('ns-spoiler', composerControlDidClick);
 
             function composerControlDidClick(textArea, selectionStart, selectionEnd) {
@@ -38,21 +38,56 @@ $(document).ready(function () {
                 return nl + tag + nl;
             }
         });
-    });
 
-    $(window).on('action:redactor.load', function () {
-        $.Redactor.prototype['ns-spoiler'] = function () {
-            return {
-                init   : function () {
-                    var button = this.button.add('ns-spoiler', 'Add Spoiler');
-                    this.button.setIcon(button, '<i class="fa fa-eye-slash"></i>');
-                    this.button.addCallback(button, this['ns-spoiler'].onClick);
-                },
-                onClick: function () {
-                    this.insert.html('<p>' + tag + '<br /><br />' + textPrompt + '<br /><br />' + tag + '</p>');
-                }
+        $(window).on('action:redactor.load', function () {
+            $.Redactor.prototype['ns-spoiler'] = function () {
+                return {
+                    init   : function () {
+                        var button = this.button.add('ns-spoiler', 'Add Spoiler');
+                        this.button.setIcon(button, '<i class="fa fa-eye-slash"></i>');
+                        this.button.addCallback(button, this['ns-spoiler'].onClick);
+                    },
+                    onClick: function () {
+                        this.insert.html('<p>' + tag + '<br /><br />' + textPrompt + '<br /><br />' + tag + '</p>');
+                    }
+                };
             };
-        };
-    });
+        });
 
+        $(window).on('action:quill.load', function (ev, quill) {
+            console.log('quill loaded');
+            require(['quill'], function (Quill) {
+                // Override the composer-default handler for ns-spoiler and use one for Quill
+                const Delta = Quill.import('delta');
+
+                formatting.addButtonDispatch('ns-spoiler', function () {
+                    const range = quill.getSelection();
+                    let insertionDelta;
+
+                    if (range.length) {
+                        insertionDelta = quill.getContents(range.index, range.length);
+                    } else {
+                        insertionDelta = new Delta().insert(textPrompt);
+                    }
+
+                    // Wrap selection in spoiler tags
+                    quill.updateContents(new Delta()
+                        .retain(range.index)
+                        .delete(range.length)
+                        .insert(range.index > 0 ? '\n' : '')
+                        .insert(tag + nl)
+                        .concat(insertionDelta)
+                        .insert(nl + tag + nl)
+                    );
+
+                    if (range.length) {
+                        // Update selection
+                        quill.setSelection(range.index + (range.index > 0 ? 5 : 4), range.length);
+                    } else {
+                        quill.setSelection(range.index + (range.index > 0 ? 5 : 4), textPrompt.length);
+                    }
+                });
+            });
+        });
+    });
 });

--- a/public/js/spoiler.js
+++ b/public/js/spoiler.js
@@ -51,8 +51,6 @@ require([
                         return console.error('Error has occurred, error: %s', error.message);
                     }
                     $content.html(content);
-                    images.unloadImages($spoiler.parents(elements.POST));
-                    images.loadImages();
                 }
             );
         }


### PR DESCRIPTION
@NicolasSiver -- the changeset:

1. Updated `nl` so it is only one newline, I think it looks better this way with less whitespace, but it is up to you
1. Added a noop listener for the ns-spoiler (this is required for quill, see comment). It does not affect composer-default
1. Moved `getTag` out to the top of page as it is used in two listeners, not just `action:composer.loaded`
1. Quill integration method, of course.

Not tested on Redactor.