### PR TITLE
fix: remove deprecated unloadImages/loadImages code

### DIFF
--- a/public/js/spoiler.js
+++ b/public/js/spoiler.js
@@ -51,8 +51,6 @@ require([
                         return console.error('Error has occurred, error: %s', error.message);
                     }
                     $content.html(content);
-                    images.unloadImages($spoiler.parents(elements.POST));
-                    images.loadImages();
                 }
             );
         }


### PR DESCRIPTION
The aforementioned methods are no longer available in core as images are not meant to be unloaded and reloaded any longer.