### PR TITLE
fix: spoilers only working in topic page

### DIFF
--- a/plugin/controller.js
+++ b/plugin/controller.js
@@ -47,10 +47,11 @@
      */
     Controller.parsePost = function (payload, callback) {
         var content     = payload.postData.content,
+            pid         = payload.postData.pid,
             rejectParse = payload.postData[constants.PARSE_REJECT_TOKEN];
 
         if (content && !rejectParse) {
-            parser.parse(content, function (error, parsedContent) {
+            parser.parse(content, pid, function (error, parsedContent) {
                 payload.postData.content = parsedContent;
                 callback(error, payload);
             });

--- a/plugin/parser.js
+++ b/plugin/parser.js
@@ -24,7 +24,7 @@
         ], done);
     };
 
-    Parser.parse = function (content, done) {
+    Parser.parse = function (content, pid, done) {
         async.waterfall([
             async.apply(Parser.prepare, content),
             function (sanitizedContent, next) {
@@ -34,7 +34,7 @@
                 // If there is a Spoiler in the content, content will be shattered on the chunks
                 while ((execResult = spoiler.exec(sanitizedContent)) !== null) {
                     textSegments[cursor] = sanitizedContent.slice(position, execResult.index);
-                    textSegments[++cursor] = `<div class="ns-spoiler" data-index="${execResult.index}" data-open="false"><div class="ns-spoiler-control"><a class="btn btn-default" href="#"><i class="fa fa-eye"></i> spoiler</a></div><div class="ns-spoiler-content"></div></div>`;
+                    textSegments[++cursor] = `<div class="ns-spoiler" data-index="${execResult.index}" data-pid="${pid}" data-open="false"><div class="ns-spoiler-control"><a class="btn btn-default" href="#"><i class="fa fa-eye"></i> spoiler</a></div><div class="ns-spoiler-content"></div></div>`;
                     // Rest content
                     textSegments[++cursor] = sanitizedContent.slice(spoiler.lastIndex);
                     position = spoiler.lastIndex;

--- a/public/js/spoiler.js
+++ b/public/js/spoiler.js
@@ -14,12 +14,12 @@ require([
         CLOSE_EYE: 'fa-eye-slash'
     };
 
-    $(window).on('action:topic.loading', function (e) {
-        addTopicListener();
+    $(window).on('action:ajaxify.end', function () {
+        addListeners();
     });
 
-    function addTopicListener() {
-        $('[component="topic"]').on("click", elements.BUTTON, function () {
+    function addListeners() {
+        $(elements.BUTTON).on("click", function () {
             toggle($(this));
         });
     }
@@ -31,6 +31,10 @@ require([
             postId   = parseInt($spoiler.parents('[data-pid]').attr('data-pid')),
             index    = parseInt($spoiler.attr('data-index')),
             icon     = $button.find('i');
+
+        if (!postId || !index) {
+            return console.warn('[ns-spoiler] data-index or data-pid missing from spoiler element!');
+        }
 
         $spoiler.attr('data-open', !open);
 

--- a/public/js/spoiler.js
+++ b/public/js/spoiler.js
@@ -28,13 +28,9 @@ require([
         var $spoiler = $button.parents(elements.MAIN),
             $content = $spoiler.find(elements.CONTENT),
             open     = $spoiler.attr('data-open') === 'true',
-            postId   = parseInt($spoiler.parents('[data-pid]').attr('data-pid')),
+            postId   = parseInt($spoiler.attr('data-pid')),
             index    = parseInt($spoiler.attr('data-index')),
             icon     = $button.find('i');
-
-        if (!postId || !index) {
-            return console.warn('[ns-spoiler] data-index or data-pid missing from spoiler element!');
-        }
 
         $spoiler.attr('data-open', !open);
 


### PR DESCRIPTION
I'd like to enable this plugin to work on other pages in NodeBB as well, which aren't specifically in a topic list. Specifically, the flag details page contains the post content, and it would be good to allow it to work there as well.

~To do so, I've added the listener directly onto `#content`, which never goes away. However, doing so is a little messy because that means this listener gets called whenever *anything* is clicked.~ Nevermind, talked myself out of it.

Instead, I could listen for `action:ajaxify.end` and attach listeners to `elements.BUTTON` directly, instead of a delegated event on `$('[component="topic"]')`.... what do you think?