### PR TITLE
fix: spoiler not working in post queue

### DIFF
--- a/plugin/controller.js
+++ b/plugin/controller.js
@@ -50,7 +50,7 @@
             pid         = payload.postData.pid,
             rejectParse = payload.postData[constants.PARSE_REJECT_TOKEN];
 
-        if (content && !rejectParse) {
+        if (content && pid && !rejectParse) {
             parser.parse(content, pid, function (error, parsedContent) {
                 payload.postData.content = parsedContent;
                 callback(error, payload);


### PR DESCRIPTION
We would like to extend the functionality of the ns-spoilers plugin so that it works in the post queue. Currently the spoiler does not show up because there is no pid assigned to the spoiler itself, and so a client-side error is logged.

If there is no pid, the spoiler will just be shown immediately, and the button itself will be disabled.