### PR TITLE
fix: spoiler not working on infinite scroll, after post is edited and…

### DIFF
--- a/public/js/spoiler.js
+++ b/public/js/spoiler.js
@@ -14,9 +14,9 @@ require([
         CLOSE_EYE: 'fa-eye-slash'
     };
 
-    $(window).on('action:ajaxify.end action:posts.edited action:posts.loaded', function () {        
+    $(window).on('action:ajaxify.end action:posts.edited action:posts.loaded', function () {
         addListeners();
-    });    
+    });
 
     function addListeners() {        
         $(elements.BUTTON).off('click').on("click", function () {

--- a/public/js/spoiler.js
+++ b/public/js/spoiler.js
@@ -18,7 +18,7 @@ require([
         addListeners();
     });
 
-    function addListeners() {        
+    function addListeners() {
         $(elements.BUTTON).off('click').on("click", function () {
             toggle($(this));
         });

--- a/public/js/spoiler.js
+++ b/public/js/spoiler.js
@@ -14,12 +14,12 @@ require([
         CLOSE_EYE: 'fa-eye-slash'
     };
 
-    $(window).on('action:ajaxify.end', function () {
+    $(window).on('action:ajaxify.end action:posts.edited action:posts.loaded', function () {        
         addListeners();
-    });
+    });    
 
-    function addListeners() {
-        $(elements.BUTTON).on("click", function () {
+    function addListeners() {        
+        $(elements.BUTTON).off('click').on("click", function () {
             toggle($(this));
         });
     }


### PR DESCRIPTION
I noticed that the button is loosing the trigger event if a post is edited. Also, when a new post is added, the spoiler button is not working. The same behavior is reproduceable when infinite scrolling is activated in pagination. 