### PR TITLE
Guest view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodebb-plugin-ns-spoiler",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "description": "Spoiler. Ability to control visibility of the content in posts. Works better with Markdown syntax.",
   "main": "./plugin/index.js",
   "scripts": {

--- a/plugin/socket-service.js
+++ b/plugin/socket-service.js
@@ -15,11 +15,7 @@
         callback();
     };
 
-    SocketService.getSpoilerContent = function (socket, payload, callback) {
-        if (!socket.uid) {
-            return callback(new Error('Connection is not authorized.'));
-        }
-
+    SocketService.getSpoilerContent = function (socket, payload, callback) {        
         controller.getSpoilerContent(Object.assign({}, {uid: socket.uid}, payload), callback);
     };
 


### PR DESCRIPTION
Current system don't allow guest to view spoiler content, we have requirement where we think that spoiler content should be allowed to viewed by any user.

Steps to reproduce: 

Go to website and do not log
find a topic containing spoiler
click on eye icon to display spoiler content
-> eye icon changes but content is not displayed